### PR TITLE
Edits

### DIFF
--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -242,14 +242,12 @@ used in further analysis.
 We note that 95\% of the selected candidate members have parallax
 signal-to-noise ratios above 24 with median signal-to-noise ratio of 170.
 From propagation of uncertainties ignoring covariances,
-formal velocity uncertainties in R.A. and Decl. direction span
+formal velocity uncertainties in the R.A. and Decl. directions span
 $0.25$--$0.79$~\kms\ and $0.05$--$0.17$~\kms\ ($25$--$75$ percentiles).
 Of 194 sources selected, there are 31 sources that have radial velocities (RVs)
 measured.
 The RV uncertainties are similarly small spanning $0.46$--$0.95$~\kms.
-The median and standard deviation of the velocities of 31 sources with RVs in
-the Galactic coordinates are $(U,\,V,\,W) = (-3.6,\,-9.1,\,-1.6)~\kms$ and
-$(\sigma_U,\,\sigma_V,\,\sigma_W) = (0.60,\,0.88,\,1.23)~\kms$.
+The median and standard deviation of the velocities of the 31 sources with RVs in the Galactic coordinates are $(U,\,V,\,W) = (-3.6,\,-9.1,\,-1.6)~\kms$ and $(\sigma_U,\,\sigma_V,\,\sigma_W) = (0.60,\,0.88,\,1.23)~\kms$.
 In \sectionname~\ref{sec:fitting}, we derive
 the isotropic velocity dispersion of the candidate members with
 forward modelling.

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -100,7 +100,7 @@
   This group, which notably includes 81 Uma and 84 Uma, spans a large area
   on sky, $(\Delta\mathrm{R.A.},\,\Delta\mathrm{Decl.})\approx(39,\,18)$~deg,
   thus allowing for a well-constrained astrometric radial velocity that agrees with spectroscopic radial velocities for a subset of members.
-  The morphology of the group is unlike that of Galactic open clusters: while relatively compact in Galactic $z$, the group displays a $XX$~pc gap in the spatial distribution in Galactic $(x, y)$ coordinates that may be an indication of ongoing disruption or dissolution.
+  The morphology of the group is unlike that of Galactic open clusters: while relatively compact in Galactic $Z$, the group displays a $XX$~pc gap in the spatial distribution in Galactic $(X, Y)$ coordinates that may be an indication of ongoing disruption or dissolution.
   \todo{list some conclusions!}
 
 \end{abstract}

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -419,6 +419,8 @@ This is in good agreement with the visually-determined isochrone age.
   \includegraphics{nuv_xray.pdf}
   \caption{$\mathrm{NUV}-\mathrm{G}$ colors of 62 \galex\ cross-matched
     candidate members in \groupTen\ as a function of their \bprp\ color.
+    White dwarfs, which extend to even bluer colors (lower left), have been removed from the field sample with a simple cut in the
+    \bprp\ vs. $M_G$ color-magnitude diagram ($M_G< 3(\bprp+0.5)+7.5$ if $\bprp<2$).
     }
   \label{fig:nuv}
 \end{figure}
@@ -437,18 +439,14 @@ We used a $2\arcsec$ and $20\arcsec$ search radius for \galex\ and 2RXS respecti
 When there are multiple \galex\ matches to a source, we choose the one with
 the smallest NUV magnitude error.
 We find that 62 of our candidate members ($\sim30$\%) have corresponding \galex\
-UV detection, of which 10 are also X-ray sources.
-There are 4 additional X-ray detected candidate members without UV detection.
+UV detections, of which 10 are also X-ray sources.
+There are 4 additional X-ray detected candidate members without UV detections.
 The $\mathrm{NUV}-\mathrm{G}$ colors of the candidate members tend
-to be at the edge of the distribution of field stars\footnote{
-  White dwarfs, which extends to even bluer colors (lower left), have been removed
-  from the field sample for \figname~\ref{fig:nuv} with a simple cut in
-  \bprp\ vs. $M_G$ color-magnitude diagram ($M_G< 3(\bprp+0.5)+7.5$ if $\bprp<2$).
-}
+to be at the edge of the distribution of field stars
 at fixed \bprp\ colors towards brighter
 $\mathrm{NUV}$ magnitudes or show UV excess (\figname~\ref{fig:nuv}).
-This is commonly seen in young stars upto ages of a few Myr old,
-providing an indepdenent qualitative confirmation of the the isochrone age.
+This is commonly seen in young stars up to ages of a few Myr old,
+providing an additional qualitative confirmation of the the isochronal age estimate.
 
 \subsection{Mean velocity and velocity dispersion}
 \label{sec:fitting}
@@ -456,35 +454,37 @@ providing an indepdenent qualitative confirmation of the the isochrone age.
 In this section, we derive the mean velocity and velocity dispersion of the
 group using either only parallaxes and proper motions or full 6D information
 including radial velocities.
-Although the original selection was done by selecting comoving pairs, we can
-also model the proper motions of the stars in the group as drawn from a single
-mean velocity and a dispersion.
+Although the original selection was done by selecting comoving pairs \citep{2017AJ....153..257O}, we can
+also model the proper motions of the stars in the group as being drawn from a low-dispersion velocity distribution around a mean value.
 Historically, the basic assumption of a group of stars having the same velocity
-has been used to derive a distance to the group (moving cluster method).
+has been used to derive a distance to the group (the ``moving cluster method'').
 % or define the membership of each star.
-However, given the exquisite measurements of parallaxes and proper motions via
-astrometry, a forward modeling of the same basic model may yield interesting
-inferences of geometric radial velocities of the group or other residual
-velocity patterns beyond the simple isotropic dispersion
-\citep{1999A&A...348.1040D,2002A&A...381..446M}
+However, given the exquisite astrometry for these nearby stars, forward-modeling the velocity distribution yields interesting
+geometric constraints on the radial velocity of the group and other residual
+velocity patterns beyond a simple isotropic dispersion
+\citep{1999A&A...348.1040D,2002A&A...381..446M}.
 
-Here, we fit the simplest model of single isotropic Gaussian component to the data.
+To model the velocity distribution of the group, we use a single isotropic Gaussian and infer the 3D mean and dispersion of this distribution given the noisy astrometric measurements from \gaia.
 The components of the model are:
 \begin{itemize}
   \item We assume that the velocity $\vec{v}_i$ of the star $i$ is drawn from
     a single Gaussian component with mean (group) velocity $\vec{u}$ and
     an isotropic dispersion $\sigma_{u}$:
-    $$\vec{v}_i \sim \normal(\vec{u},\,\sigma_{u}).$$
+    \begin{equation}
+        \vec{v}_i \sim \normal(\vec{u},\,\sigma_{u}).
+    \end{equation}
     Then, the proper motion of star $i$ is
-    $\transp{(\pmra,\,\pmdec)} = \mat{M}_i(\alpha_i,\,\delta_i) \vec{v}_i / r_i$ where
+    $\transp{(\pmra,\,\pmdec)} = \mat{M}_i(\alpha_i,\,\delta_i) \, \vec{v}_i / r_i$ where
     $\mat{M}_i$ is the rotation matrix that transforms the equatorial
     rectangular coordinates to the tangential coordinates at the location
     $(\mathrm{R.A.},\,\mathrm{Decl.}) = (\alpha_i,\,\delta_i)$.
 
   \item We assume that the noise model for the \gaia\ data is Gaussian, and
     the covariance matrix $\mat{C_i}$ is given and fixed:
-    $$(\tilde\varpi_i,\,\tilde\mu_{\alpha,i}^*,\,\tilde\mu_{\delta,i}) \sim
-      \normal((\varpi_i,\,\mu_{\alpha,i}^*,\,\mu_{\delta,i}),\,\mat{C_i})$$
+    \begin{equation}
+    (\tilde\varpi_i,\,\tilde\mu_{\alpha,i}^*,\,\tilde\mu_{\delta,i}) \sim
+      \normal((\varpi_i,\,\mu_{\alpha,i}^*,\,\mu_{\delta,i}),\,\mat{C_i})
+    \end{equation}
 
   \item \emph{Priors}:
     We assume an uninformative uniform prior in distance and a broad Gaussian
@@ -500,21 +500,19 @@ In this case, the radial velocity is just $v_{r,i} =
 where $\hat{\vec{u}}_r(\alpha_i,\,\delta_i)$ is the unit radial vector
 and the covariance of the noise model
 is extended as $\mathrm{diag}(\mat{C_i},\,\sigma_{v_r}^2)$.
-We refer the model using proper-motions only of all candidate member stars as `PM only'
+We refer to the model using proper-motions only of all candidate member stars as `PM only'
 and the model using a subset of 38 stars with RVs as `PM+RV' respectively.
-For each case, we first do an optimization using L-BFGS algorithm starting from
+For each case, we first optimize the likelihood of each model using the L-BFGS \todo{citation for LBFGS} algorithm starting from
 the initial values $d_{i,0} = 1/{\tilde \varpi_i}$, a random mean velocity
 $\vec{u}_0$ and $\sigma_u=10$~\kms.
-We then sample the posterior distribution of $d_i$, $\vec{u}$ and $\sigma_u$
+We then sample the posterior distribution of $d_i$, $\vec{u}$, and $\sigma_u$
 starting from this optimum.
 
-This fitting achieves two main goals.
+This modeling procedure achieves two main goals.
 First, it properly deconvolves the uncertainty of each measurements taking
 covariances between parallax and proper motions into account.
-Secondly, for `PM only' case, this derives the geometric (astrometric) velocity
-of the group, which can be compared to the spectroscopic RVs from \gaia\ DR 2
-for a subset of stars.
-This may be particularly interesting as \groupTen\ has a large angular span
+Secondly, for the `PM only' case, this derives the geometric (astrometric) velocity of the group, which can be compared to the spectroscopic RVs from \gaia\ DR 2, available for a subset of stars.
+This is particularly interesting as \groupTen\ has a large angular span
 ($(\Delta\mathrm{R.A.},\,\Delta\mathrm{Decl.})\approx(39,\,18)$~deg)
 and the astrometric precision is generally excellent.
 
@@ -531,19 +529,19 @@ and the astrometric precision is generally excellent.
   \label{fig:fit}
 \end{figure}
 
-\figname~\ref{fig:fit} summarizes and compares the fit result for the two cases.
+\figname~\ref{fig:fit} summarizes and compares the result of the modeling procedure described above for the two cases.
 Because this group spans a large area on sky, all three components of the mean
-velocity is well-contrained geometrically using proper-motions only
+velocity are well-constrained geometrically even when only using proper-motions
 (black density and contours).
 The mean and standard deviation of the posterior samples of the mean velocity $\vec{u}$
 is $(u_x,\,u_y,\,u_z) = (-3.82\pm0.19,\,6.84\pm0.14,\,-4.00\pm0.34)$ in
 equatorial coordinates.
 The velocity dispersion is very small with the mean of the posterior samples at
 $\approx 0.73$~\kms.
-The fit result of `PM only' is in good agreement with `PM+RV' case
+The fit result of `PM only' is in good agreement with the `PM+RV' case
 with the mean velocity of $(-3.02\pm0.13,\,7.41\pm0.14,\,-5.89\pm0.13)$ and
 the mean dispersion of $0.82$~\kms (orange density and contours).
-While the differences between the two models is significant formally,
+While the differences between the two models is formally significant,
 the difference is very small $<1$~\kms.
 
 \subsection{Morphology}

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -557,22 +557,21 @@ the difference is very small $<1$~\kms.
   \label{fig:orbit_morphology}
 \end{figure}
 
-The distribution of candidate members show no discernable center or
-contentration in the Galactic $X$-$Y$ coordinates while it seems highly
+Figure~\ref{fig:orbit_morphology} shows the spatial distribution of candidate members of \groupTen: The spatial distribution shows no discernible center or
+concentration in Galactic $X$-$Y$ coordinates, while it seems highly
 concentrated in $Z$ direction around the median height of $\approx 82$~pc above
-the Galactic plane (Figure~\ref{fig:orbit_morphology}).
-The nominal standard deviation in $X$, $Y$, and $Z$ coordinates
+the Galactic plane.
+The empirical standard deviation in $X$, $Y$, and $Z$ coordinates
 is $6.7$, $10$, and $4.3$ pc respectively.
 Furthermore, the candidate members seem to be divided in their $X$-$Y$
-distribution, leaving a band of gap that is tilted with respect to the direction
-of Galactic rotation ($+Y$).
-The bottom panels of \figname~\ref{fig:orbit_morphology} shows the
+distribution, with a visible banded under-density or gap that is tilted with respect to the direction of Galactic rotation ($+Y$).
+The bottom panels of \figname~\ref{fig:orbit_morphology} show the
 nearly-circular orbit of the group integrated backwards for $300$~Myr in a Milky
 Way potential \citep{2015ApJS..216...29B} using the mean velocity derived from
 `PM+RV' model fitting in \sectionname~\ref{sec:fitting} and the median position
-marked by a black `x' in the top panels of the same \figname.
+marked by a black `x' in the top panels of the same \figname \todo{what figure?}.
 
-We can roughly estimate the total mass of the group using BP-RP colors
+We estimate the total mass of the group using BP-RP colors
 and a model isochrone assuming an initial mass function (IMF).
 We interpolate the BP-RP color-initial mass relation of a PARSEC isochrone of
 solar metallicity and $\log\mathrm{age}=8.4$.
@@ -584,28 +583,26 @@ Since the total mass of 124 candidate members within this color range is
 $70~M_\odot$, the total mass is estimated to be $\approx167~M_\odot$.
 This is likely a lower limit because
 the membership selection may not be complete while the contamination is expected
-to be low and because binarities are not taken into account.
+to be low and because binaries are not taken into account.
 
 % The group is unlikely to be graviationally bound.
 % From kernel density estimation of the
 % the $XYZ$ coordinates of the candidate members,
 % the number density of the group in the densest region is $\approx0.03~\pc^{-3}$.
 
-We speculate on the origin of the morphology of the group,
-which is reminiscent of tidal tails.
-One trivial possibility is that this particular group simply formed this way and
-has not had the time to disperse yet.
+The morphological asymmetries are peculiar and reminiscent of tidal tails, but other plausible explanations are consistent with the data at hand.
+One possible explanation is that this group formed this way and
+has not had time to disperse.
 Unlike the classical open clusters, for the smaller local associations of young stars
 with typical ages less than 100 Myr,
 it is often assumed that the gravitational interaction between member stars
-is not important, and their dynamics is governed by the initial condition and
+is not important, and their dynamics is governed by the initial conditions and
 the Galactic potential \citep{1997MNRAS.285..479B,2018arXiv180300573M}.
 Based on these assumptions, tracing back the orbits of the stars to a converging point
 can result in a dynamical estimate of their ages.
-However, simple expansion does not offer any explanation for the presense of the game
-nor the highly anisotropic stretch of the morphology of \groupTen.
-The age of \groupTen\ is significantly older than most local associations to
-which such analysis is applied, which typically are tens of Myr old.
+However, simple expansion does not offer any explanation for the presence of the gap nor the highly anisotropic stretch of the morphology of \groupTen.
+In addition, the age of \groupTen\ is significantly older than most local associations to
+which such analysis is applied, which are typically just tens of Myr old.
 Given the velocity dispersion of $0.6$~\kms\ and an age of $200$~Myr,
 if the group has been expanding shortly after the star formation,
 it should now be spread over $>120$~pc.
@@ -617,9 +614,9 @@ Star clusters that survive the infant mortality are thought to be eventually
 disrupted by the Galactic tidal field or encounters with Giant Molecular Clouds
 (GMCs).
 As stars in a cluster gain energy from external perturbations, they escape
-primarily through $L_1$ and $L_2$ Lagrange points (Heggie 2001), which are
-separated by $2r_J$ where $r_J$ is the tidal (or Jacobi) radius of the cluster.
-For a cluster like \groupTen\ in the Solar neighborhoood with nearly circular orbit,
+primarily through the $L_1$ and $L_2$ Lagrange points (\todo{Heggie 2001}), which are
+separated by $2r_J$, where $r_J$ is the tidal (or Jacobi) radius of the cluster.
+For a cluster like \groupTen\ in the solar neighborhood with a nearly circular orbit,
 the tidal radius due to the Galactic tides is \citep{2010ARA&A..48..431P}
 \begin{equation}
   \begin{split}
@@ -636,7 +633,7 @@ are always aligned with the Galactic center, will then move away with velocities
 close to the mean velocity of the cluster.
 However, as indicated by the arrows in \figname~\ref{fig:orbit_morphology}, the
 stretch of the group in $X-Y$ coordinates is significantly tilted from the mean
-velocity although it does agree in $X-Z$ coordinates.
+velocity, though it does agree in $X-Z$ coordinates.
 Furthermore, it is unclear whether a small cluster under the influence of the
 Galactic tides throughout its lifetime of $\gtrsim 200$~Myr should still be
 detectable as an overdensity in velocity space.
@@ -657,17 +654,17 @@ this morphology.
 We confirmed and characterized a new nearby coeval comoving group first detected
 in the Tycho-Gaia Astrometric Solution (\tgas) of \gaia\ DR 1 with
 the independent and much improved data of \gaia\ DR 2.
-We select a total of 194 candidate members with DR 2 astrometry
+We select a total of 194 candidate members with DR 2 astrometry,
 vastly improving the census of the group which was originally detected as
 interconnected comoving pairs of 29 stars.
 The age of the group is estimated to be $\approx200-250$~Myr from
 matching the \gaia\ color-magnitude diagram with theoretical isochrones.
-Some of the candidate members show independent sign of youth in their
-UV and X-ray properties.
-The group, which standed out from our previous search as the largest nearby
+Some of the candidate members show independent signs of youth from their
+UV and X-ray photometry.
+The group, which stood out in our previous search as the largest nearby
 coeval moving group with little prior discussion in the literature,
-shows an interesting morphology in their Galactic $X-Y$ distribution
-which looks like broad tidal tails separated by an underdensity.
+shows an interesting morphology in the Galactic $X-Y$ spatial distribution
+that looks like broad tidal tails separated by an apparent underdensity.
 While we speculate on the possibility that the morphology may be related
 to the disruption of a small star cluster,
 not all features are easily explained and further

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -96,17 +96,12 @@
 
 \begin{abstract}
 
-  We confirm and characterize a nearby ($d \approx \groupDistanceEstimate$),
-  young (age$\approx 250$~Myr) moving group discovered with \gaia\ DR 1
-  astrometry using the updated and extended data from \gaia\ DR 2 in combination
-  with other data from the literature.
+  We confirm and characterize a recently discovered, nearby ($d \approx \groupDistanceEstimate$), young (age$\approx 250$~Myr) moving group using astrometric and photometric data from \gaia\ DR 2 combined with spectroscopic data compiled from the literature.
   This group, which notably includes 81 Uma and 84 Uma, spans a large area
-  on sky ($(\Delta\mathrm{R.A.},\,\Delta\mathrm{Decl.})\approx(39,\,18)$~deg),
-  thus giving a well-constrained astrometric radial velocity from geometry alone,
-  which agrees with spectroscopic radial velocities for a subset of members.
-  The morphology of the group in the Galactic $X-Y$ coordinates shows an
-  interesting gap while highly contentrated in $Z$ direction.
-  We discuss possible origins of the gap in relation to the disruption of the group.
+  on sky, $(\Delta\mathrm{R.A.},\,\Delta\mathrm{Decl.})\approx(39,\,18)$~deg,
+  thus allowing for a well-constrained astrometric radial velocity that agrees with spectroscopic radial velocities for a subset of members.
+  The morphology of the group is unlike that of Galactic open clusters: while relatively compact in Galactic $z$, the group displays a $XX$~pc gap in the spatial distribution in Galactic $(x, y)$ coordinates that may be an indication of ongoing disruption or dissolution.
+  \todo{list some conclusions!}
 
 \end{abstract}
 

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -108,13 +108,12 @@
 \section{Introduction} % (fold)
 \label{sec:introduction}
 
-Comoving, coeval stars in the Solar neighborhood are valuable astrophysics
-laboratories for studying stellar properties, stellar evolution and galactic
+Comoving, coeval stars in the Solar neighborhood are valuable astrophysical
+laboratories for studying stellar properties, stellar evolution, and galactic
 dynamics \citep[e.g.,][]{2018arXiv180409378G,2018MNRAS.tmp.1228M}.
-Multiple stars form in each molecular cloud often in kinematically coherent
+Multiple stars form in each molecular cloud, often in kinematically coherent
 groups.
-Galactic dynamics determine how and when these groups eventually  dissolved into
-the field population.
+Galactic dynamics determines how and when these groups eventually dissolve into the field population.
 Thus, a detailed census of these objects traces both recent star formation
 history in the local volume as well as the dynamics of their disruption.
 Individual star clusters or coeval moving groups are also interesting dynamical
@@ -125,12 +124,8 @@ Finally, within $\approx 100$~pc, members of young stellar groups represent the
 best samples to study dusty debris disk, exopalnets and brown dwarfs through
 direct imaging.
 
-\gaia's second  data release \citep[][DR 2]{2018arXiv180409365G} marks a new
-era in charting the kinematic substructure and stellar populations in the Solar
-neighborhood.
-It provides parallaxes, proper motions and precise two-band photometry of stars
-brighter than $G=20$ as well as radial velocities for stars brighter than
-$G=12$.
+The second data release from the \gaia mission \citep[][DR 2]{2018arXiv180409365G} marks a new era for charting the kinematic substructure and stellar populations in the solar neighborhood.
+\gaia DR 2 provides parallaxes, proper motions, and precise two-band photometry of stars brighter than $G\lesssim 20.7$ as well as radial velocities for stars brighter than $G\lesssim12.5$.
 \citet{2017AJ....153..257O} presents a search for comoving pairs using the
 Tycho-Gaia Astrometric Solution (\tgas), a subset of \gaia\ DR~1 which provides
 astrometric measurements for 2~million sources in Tycho-2 catalog ($G<12$~mag).

--- a/paper/groupten.tex
+++ b/paper/groupten.tex
@@ -338,18 +338,17 @@ forward modelling.
   \includegraphics{age_DavidHillenbrand2015.pdf}
   \caption{Age estimates for five candidate members by \citet{2015ApJ...804..146D}.
     For each star, the black vertical line is the mode of the posterior
-    distribution, and the gray band and line marks 68\% and 95\% confidence
-    interval.
+    distribution, and the gray band and line mark the 68\% and 95\% confidence
+    intervals, respectively.
   }
   \label{fig:age_DavidHillenbrand2015}
 \end{figure}
 
-Figure~\ref{fig:cmd}a shows the color-magnitude diagrams of the candidate group
-members using the \gaia\ photometry.
-The absolute $G$ magnitude $M_G$ is calculated as $G + 5\log(\varpi) -10$ where
-$\varpi$ is parallax in mas.
+Figure~\ref{fig:cmd}a shows the color-magnitude diagram of the candidate group
+members using the \gaia\ photometry \todo{and of all stars within XX pc (blue shaded background)}.
+The absolute $G$ magnitude, $M_G$, is calculated as $G + 5\log(\varpi) - 10$ where $\varpi$ is the \gaia-measured parallax in milliarcseconds.
 The group is at a high galactic latitude (median $b=55$~degrees),
-and the extinction is very low.
+and the extinction is very low:
 We checked the dust maps of \citet{1998ApJ...500..525S} and
 \citet{2017ApJ...846...38L}
 at the location of candidate members and found the median reddening to be
@@ -357,18 +356,18 @@ $E(B-V)\lesssim 0.012$~mag although there are some variations across the region 
 the maximum reddening of 0.025~mag.
 We applied no correction for dust to the data or isochrone models.
 
-The candidate members (black and red circles) resemble a clean single-age population
+The candidate members (black and red circles) resemble a clean, single-age population
 that lies on a very narrow main-sequence compared to the ``field'' stars within $100$~pc.
 The field sample was constructed by querying all stars with parallax $\varpi>10$~mas,
 parallax signal-to-noise ratio over 50 and good \bprp\ colors filtered by
-\texttt{phot\_bp\_rp\_excess\_factor} accordning to cuts in \citet{2018arXiv180409378G}.
+\texttt{phot\_bp\_rp\_excess\_factor} according to quality cuts in the Appendix of \citet{2018arXiv180409378G}.
 
 How old is \groupTen?
 In order to estimate an approximate age of the group,
-we compared the distribution of candidate members in the color-magnitude diagram
+we visually compared the distribution of candidate members in the color-magnitude diagram
 to MIST \citep[][with rotation]{2016ApJ...823..102C} and
 PARSEC isochrones \citep[v1.2S;][]{2012MNRAS.427..127B,2015MNRAS.452.1068C}
-of solar metallicity visually,
+of solar metallicity,
 and found $\log(\mathrm{age}) \approx 8.4$ (250~Myr) to be a good fit.
 A range of $\log(\mathrm{age}) = (8.2-8.55)$ encapsulates the plausible
 age of the group judging from the disagreement in lower-main sequence for
@@ -379,7 +378,7 @@ for comparison.
 The discrepancy between the MIST models and the data for low-mass
 ($M\lesssim0.6~m_\odot$) stars is a well-known problem seen in many young open
 clusters or associations and generic in many stellar models, and is attributed
-to incomplete atomic and molecular line opacity data.
+to incomplete atomic and molecular line opacity data \todo{add citation}.
 This is remedied in PARSEC models by revising and calibrating the boundary
 conditions to match the observed star clusters
 \citep{2014MNRAS.444.2525C}, leading to a better agreement with the data.
@@ -390,21 +389,20 @@ What are the sources in between the main-sequence and the white dwarf sequence?
 At the very faint end, the \gaia\ BP-RP colors may be incorrect due to
 contamination from nearby sources as no deblending was performed for BP and RP
 bands in DR~2 \citep{2018arXiv180409368E}.
-Following \citet{2018arXiv180409378G}, we used emperical cuts to the
+Following \citet{2018arXiv180409378G}, we use empirical cuts in the
 \texttt{phot\_bp\_rp\_excess\_factor} as a function of BP-RP color in order to
-flag these sources which are marked as `\texttt{x}' in all panels of
+flag these sources, which are marked as `\texttt{x}' in all panels of
 Figure~\ref{fig:cmd}.
 In order to illuminate the nature of these sources, we use four other deeper
-survey magnitudes (\tmass\ $J$, \allwise\ $W1$ and \panstarrs\ $r$ and $y$) with
+survey magnitudes (\tmass\ $J$, \allwise\ $W1$, \panstarrs\ $r$ and $y$) with
 \gaia\ $G$ band magnitudes.
-\figname~\ref{\fig:cmd}c-e show the color-magnitude diagrams using these photometry.
+\figname~\ref{fig:cmd}c--e show the color-magnitude diagrams using these photometry.
 %
-Many of these sources seem to be lower-mass stars further down the main-sequence
-with even redder colors.
+Several of these outliers in the \gaia color-magnitude diagram appear to be low-mass stars consistent with being on the lower main sequence in other color combinations.
 
 For five \hipparcos\ stars of the candidate members,
 an independent age determination by \citet{2015ApJ...804..146D} exists.
-The stars were treated as field stars and modelled individually.
+The stars were treated as field stars and modeled individually.
 We used the cross-match to Tycho-2 provided in the Gaia Archive
 in order to retrieve the \hipparcos\ identifiers.
 Figure~\ref{fig:age_DavidHillenbrand2015} shows the posterior distributions
@@ -425,18 +423,17 @@ This is in good agreement with the visually-determined isochrone age.
   \label{fig:nuv}
 \end{figure}
 
-Young low-mass stars with a substantial convective layer stand out from
-field stars in their enhanced UV and X-ray emission
-as a result of strong internal magnetic dynamo coupled with rapid rotation
-enhancing chromospheric and coronal activity
+Young low-mass stars with substantial convective layers stand out from
+field stars in their enhanced ultraviolet (UV) and X-ray emission:
+a strong internal magnetic dynamo coupled with rapid rotation enhances chromospheric and coronal activity
 \citep{2004ARA&A..42..685Z,2008hsf2.book..757T,2011ApJ...727....6S,2013ApJ...774..101R}.
-Thus, the UV and X-ray photometry can provide an independent indication of youth
+Thus, UV and X-ray photometry can provide an independent indication of age
 for young stars in a coeval moving group.
-We checked the UV and X-ray detection of
-the candidate members by cross-mathing to the \galex\ source catalog
+We checked the UV and X-ray detections of
+the candidate members by cross-matching to the \galex\ source catalog
 \citep{2005ApJ...619L...1M} and the \rosat\ all-sky survey
 \citep[2RXS;][]{2016A&A...588A.103B}.
-We used $2\arcsec$ and $20\arcsec$ search radius for \galex\ and 2RXS respectively.
+We used a $2\arcsec$ and $20\arcsec$ search radius for \galex\ and 2RXS respectively.
 When there are multiple \galex\ matches to a source, we choose the one with
 the smallest NUV magnitude error.
 We find that 62 of our candidate members ($\sim30$\%) have corresponding \galex\


### PR DESCRIPTION
Overall, I think the plots are there and describe an interesting result! However, I think the text still needs some work. I made some direct edits to the text to fix spelling, phrasing, but have raised some larger points or things that need more substantial additions / modifications below. Let me know if you have any questions, or need any help.

### General notes:
* I think "solar" should be lower case.
* I think you could give Group 10 a name, and just mention in the data section that this was discovered as Group 10 in Oh et al 2017.
* The text switches between present tense / past tense. For example, "we use" vs. "we used". I prefer present tense and I think it's more common, but it's ultimately a matter of style.
* I would recommend turning on spell check in your editor. It's a lifesaver for me!
* You should include a "Software" section with the AAS software tag, and cite, e.g.,
```latex
\software{
    \texttt{Astropy} \citep{astropy13, astropy18},
    \texttt{gala} \citep{gala},
    \texttt{IPython} \citep{ipython},
    \texttt{matplotlib} \citep{mpl},
    \texttt{numpy} \citep{numpy},
    \texttt{scipy} \citep{scipy}
}
```
(see all the way at bottom for bibtex). Also add `corner.py`, `emcee`?
* Did you switch to using galpy to integrate the orbit? If so, add to software...
* Try to avoid words like "just", "trivial", "simply" - these are often unnecessarily dismissive.


### Notes about figures:

#### Figure 1:
* I would make the blue points black to make them stand out more (especially when viewed in black and white).
* You have cos(delta) in the bottom right panel, but not in the bottom left - you could put $\mu_\alpha \, \cos{\delta}$ to be consistent


### Title and abstract:
* Title could be more exciting, and could reference that this is a Gaia discovery and characterization
* In the abstract, you quote the angular span of data in ICRS coordinates. It occurs to me that, depending on the declination, there are cos(delta) effects from the spherical coordinates - do you take this into account for ∆RA?
* Why capital X, Y, Z vs. lower case? Was this a conscious decision or just your convention? I guess I see both, but more often see / am used to lower case.


### 1. Introduction:
* The introduction needs some rearranging and expansion. Right now, the first sentence makes very broad statements, but the paragraph doesn't go into too much detail about why comoving, coeval stars are useful. I would change the first sentence to, e.g.:

"Comoving, coeval stars in the solar neighborhood are valuable laboratories for studying a wide range of astrophysical phenomena from stellar models to the nature of dark matter (...)." Then expand the topics you mention and be more specific. "Galactic dynamics" sounds too vague to me - you could instead say "global and small-scale properties of Galactic mass," and cite one Chaname paper. "Stellar properties" and "stellar evolution" are very broad - specifically call out connection to chemical tagging (e.g., Ness, Hogg papers looking at open clusters), calibrating stellar models (e.g., Brewer+2016), etc. i.e. give some (few, but concrete) specific examples of how they can be used in each of the topics you raise.

* I think you could briefly discuss differences between and characteristics of moving groups, open clusters, and associations to set the context for your discussion about Group 10.

* What is now the second paragraph of the introduction jumps around a lot, and feels out of order to me. I would split the 2nd paragraph and make each of the following themes a separate paragraph and expand the text a bit:

(a) The era of Gaia / the Gaia mission in general: goals, astrometry, what it will allow us to do by end-of-mission. The precision and volume of data provides an unprecedented view of stars in the solar neighborhood.

(b) Using data from Gaia DR1 / TGAS, searched for and found many nearby comoving multiplets. Found wide binaries and larger multiplets. One of the larger multiplets is Group 10. However, only have brightest stars in group because of limitations of TGAS.

(c) Since its discovery, 2nd data release from Gaia mission has become public. Now can look at lower main sequence - with numbers, can characterize the group

* End the introduction by teasing some interesting results. i.e. don't just state "we study Group 10" - briefly mention some of its properties, and highlight again the interesting morphology. I think the novelty of this group is its interesting spatial structure and possibility that it is an association caught in the act of dissolution: tell this to the reader up front so they know what to read for.

* Split the "paper trajectory" into a separate paragraph. "We summarize previous analyses..."


### 2. Previous identifications

* Move this section either after the "Data and Sample" section, or to become a part of that section. I think it would flow more naturally after you discuss Group 10 is in the data section.

### 3. Data and sample

* I think you need to start with a few sentences summarizing how you rediscovered it (i.e. summarize Oh+2017) - you don't need to go into exhaustive detail, but you need to set the context. For example, people will probably wonder why this is called "Group 10" - you can't assume that they have read Oh+2017 (or remember it!).

* I think you need some more detail about the GMM: how do you do the fit? Do you use an existing implementation, e.g., in scikit-learn and if so, cite scikit-learn. Comment on the fact that something like extreme deconvolution would be more correct, but that the uncertainties here are so small (is that true?) that it doesn't matter.

* "there are 31 sources that have radial velocities (RVs) measured" - from Gaia? Or from literature compilation?

* Which Galactic UVW system do you use? Does U increase toward galactic center or away? (If you use Astropy, you can state "use convention in astropy" or something like that)

### 4. Analysis

#### 4.1

* I personally don't like the idea of starting paragraphs in this section with questions. That feels more appropriate for a 'discussion' section, rather than a description of the analysis. I would instead just state what you did: "We determine an approximate age of the group by visually comparing the color-magnitude diagram of candidate members with isochrones. We compare with isochrones from both MIST (...) and PARSEC (...)... etc." But, ultimately up to you!

* This sentence should be restructured "For five \hipparcos\ stars of the candidate members, an independent age determination by \citet{2015ApJ...804..146D} exists."

#### 4.3

* Some might object to using a prior on the velocity dispersion that can go negative - why do you use a Gaussian prior on the dispersion? If you want to use a Gaussian, then do it in log-dispersion. For example: ln s ~ N(0, 4)

* Have you considered including an outlier model in this part of the modeling, just in case? Go up to a 2 component Gaussian mixture and force the dispersion of the 2nd component to be > dispersion of the 1st component.

* Define \mathcal{N}

#### 4.4

* I would move the paragraph about estimating the mass up to 4.1 - I think it fits more naturally with the discussion about the CMD. It also splits up the discussion abotu the orbit, and the discussion about the morphology, which I think more naturally flow together.

### 5. Summary

* Switch to present tense?

* "Further observational investigation is needed" - I think you need to expand on this statement. What would help distinguish the scenarios? Detailed chemistry? More radial velocities? Deeper photometry?



### Bibtex:

```
@article{astropy13,
	Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
	Adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
	Archiveprefix = {arXiv},
	Author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and {Aldcroft}, T. and {Davis}, M. and {Ginsburg}, A. and {Price-Whelan}, A.~M. and {Kerzendorf}, W.~E. and {Conley}, A. and {Crighton}, N. and {Barbary}, K. and {Muna}, D. and {Ferguson}, H. and {Grollier}, F. and {Parikh}, M.~M. and {Nair}, P.~H. and {Unther}, H.~M. and {Deil}, C. and {Woillez}, J. and {Conseil}, S. and {Kramer}, R. and {Turner}, J.~E.~H. and {Singer}, L. and {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and {Edwards}, Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey}, A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and {Ely}, J. and {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and {Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal}, B. and {Servillat}, M. and {Streicher}, O.},
	Doi = {10.1051/0004-6361/201322068},
	Eid = {A33},
	Eprint = {1307.6212},
	Journal = {\aap},
	Keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
	Month = oct,
	Pages = {A33},
	Primaryclass = {astro-ph.IM},
	Title = {{Astropy: A community Python package for astronomy}},
	Volume = 558,
	Year = 2013,
	Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}

@ARTICLE{astropy18,
       author = {{The Astropy Collaboration} and {Price-Whelan}, A.~M. and
        {Sip{\'{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L.
        and {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and
        {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and
        {VanderPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-
        Su{\'a}rez}, D. and {de Val-Borro}, M. and {Aldcroft}, T.~L. and
        {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and
        {Ardelean}, C. and {Babej}, T. and {Bachetti}, M. and {Bakanov},
        A.~V. and {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P.
        and {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and
        {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and
        {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and
        {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and
        {Cano Rodr{\'\i}guez}, J.~L. and {Cara}, M. and {Cardoso},
        J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Crichton}, D.
        and {D{\'A}vella}, D. and {Deil}, C. and {Depagne}, {\'E}. and
        {Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and
        {Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira},
        L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H.
        and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R.
        and {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and
        {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D.
        and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and
        {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and
        {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern},
        N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J.
        and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and
        {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z.
        and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C.
        and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and
        {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and
        {Nelson}, S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and
        {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K.
        and {Parley}, N. and {Pascual}, S. and {Patil}, R. and {Patil},
        A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and
        {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and
        {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and
        {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and
        {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and
        {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and
        {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and
        {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V.
        and {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins},
        L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez},
        J. and {Zabalza}, V.},
        title = "{The Astropy Project: Building an inclusive, open-science project and
        status of the v2.0 core package}",
      journal = {ArXiv e-prints},
     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
         year = 2018,
        month = Jan,
          eid = {arXiv:1801.02634},
        pages = {arXiv:1801.02634},
archivePrefix = {arXiv},
       eprint = {1801.02634},
       adsurl = {https://ui.adsabs.harvard.edu/#abs/2018arXiv180102634T},
      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}

@article{mpl,
	Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
	Adsurl = {http://adsabs.harvard.edu/abs/2007CSE.....9...90H},
	Author = {{Hunter}, J.~D.},
	Doi = {10.1109/MCSE.2007.55},
	Journal = {Computing in Science and Engineering},
	Keywords = {Python, Scripting languages, Application development, Scientific programming},
	Month = may,
	Pages = {90-95},
	Title = {{Matplotlib: A 2D Graphics Environment}},
	Volume = 9,
	Year = 2007,
	Bdsk-Url-1 = {https://dx.doi.org/10.1109/MCSE.2007.55}}

@article{numpy,
	Acmid = {1957466},
	Address = {Piscataway, NJ, USA},
	Author = {Walt, Stefan van der and Colbert, S. Chris and Varoquaux, Gael},
	Doi = {10.1109/MCSE.2011.37},
	Issn = {1521-9615},
	Issue_Date = {March 2011},
	Journal = {Computing in Science and Engg.},
	Keywords = {NumPy, Python, Python, NumPy, scientific programming, numerical computations, programming libraries, numerical computations, programming libraries, scientific programming},
	Month = mar,
	Number = {2},
	Numpages = {9},
	Pages = {22--30},
	Publisher = {IEEE Educational Activities Department},
	Title = {The NumPy Array: A Structure for Efficient Numerical Computation},
	Url = {http://dx.doi.org/10.1109/MCSE.2011.37},
	Volume = {13},
	Year = {2011},
	Bdsk-Url-1 = {http://dx.doi.org/10.1109/MCSE.2011.37}}

@misc{scipy,
	Author = {Eric Jones and Travis Oliphant and Pearu Peterson and others},
	Title = {{SciPy}: Open source scientific tools for {Python}},
	Url = {http://www.scipy.org/},
	Year = {2001--},
	Bdsk-Url-1 = {http://www.scipy.org/}}

@article{gala,
	Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
	Adsurl = {http://adsabs.harvard.edu/abs/2017JOSS....2..388P},
	Author = {{Price-Whelan}, A.~M.},
	Doi = {10.21105/joss.00388},
	Eid = {388},
	Journal = {The Journal of Open Source Software},
	Keywords = {galactic dynamics, python, stellar kinematics},
	Month = oct,
	Pages = {388},
	Title = {{Gala: A Python package for galactic dynamics}},
	Volume = 2,
	Year = 2017,
	Bdsk-Url-1 = {https://dx.doi.org/10.21105/joss.00388}}

@article{ipython,
	Author = {P\'erez, Fernando and Granger, Brian E.},
	Date-Added = {2017-08-04 07:38:09 +0000},
	Date-Modified = {2017-08-04 07:38:09 +0000},
	Doi = {10.1109/MCSE.2007.53},
	Issn = {1521-9615},
	Journal = {Computing in Science and Engineering},
	Month = may,
	Number = {3},
	Pages = {21--29},
	Publisher = {IEEE Computer Society},
	Title = {{IP}ython: a System for Interactive Scientific Computing},
	Url = {http://ipython.org},
	Volume = {9},
	Year = 2007,
	Bdsk-Url-1 = {http://ipython.org},
	Bdsk-Url-2 = {http://dx.doi.org/10.1109/MCSE.2007.53}}
```
